### PR TITLE
Methods and getters should refer to proxied data instead of original data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# 2019-05-21 - v2.4.0
+
+ - Add support for javascript getters, previously it used to get called using original values.
+
+```ts
+const proxy = Sakota.create({
+    x: 1,
+    get xx() {
+        return Math.pow(this.x, 2);
+    },
+})
+proxy.x = 10;
+console.log(proxy.xx) // 100
+```
+
 # 2019-03-14 - v2.3.0
 
  - Add a method `cloneProxy` to clone a sakota proxy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/sakota",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/sakota",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Proxies js objects and records all changes made on an object without modifying the object.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -197,6 +197,172 @@ describe('Sakota', () => {
       change: { $set: { z: val } },
     })),
 
+    // getting a value using getter functions in target
+    // ------------------------------------------------
+    () => ({
+      target: {
+        x: 1,
+        y: 2,
+        get d() {
+          return this.x + this.y;
+        },
+      },
+      action: (obj: any) => {
+        obj.x = 10;
+      },
+      result: { x: 10, y: 2, d: 12 },
+      change: {
+        $set: { x: 10 },
+      },
+    }),
+
+    // getting a value using getter functions in target (nested)
+    // ---------------------------------------------------------
+    () => ({
+      target: {
+        t: {
+          x: 1,
+          y: 2,
+          get d() {
+            return this.x + this.y;
+          },
+        },
+      },
+      action: (obj: any) => {
+        obj.t.x = 10;
+      },
+      result: { t: { x: 10, y: 2, d: 12 } },
+      change: {
+        $set: { 't.x': 10 },
+      },
+    }),
+
+    // getting a value using getter functions in prototype
+    // ---------------------------------------------------
+    () => ({
+      target: new class {
+        x = 1;
+        y = 2;
+        get d() {
+          return this.x + this.y;
+        }
+      }(),
+      action: (obj: any) => {
+        obj.x = 10;
+        expect(obj.d).toEqual(12);
+      },
+      result: { x: 10, y: 2 },
+      change: {
+        $set: { x: 10 },
+      },
+    }),
+
+    // getting a value using getter functions in prototype (nested)
+    // ------------------------------------------------------------
+    () => ({
+      target: {
+        t: new class {
+          x = 1;
+          y = 2;
+          get d() {
+            return this.x + this.y;
+          }
+        }(),
+      },
+      action: (obj: any) => {
+        obj.t.x = 10;
+        expect(obj.t.d).toEqual(12);
+      },
+      result: { t: { x: 10, y: 2 } },
+      change: {
+        $set: { 't.x': 10 },
+      },
+    }),
+
+    // getting a value using method functions in target
+    // ------------------------------------------------
+    () => ({
+      target: {
+        x: 1,
+        y: 2,
+        getD() {
+          return this.x + this.y;
+        },
+      },
+      action: (obj: any) => {
+        obj.x = 10;
+        expect(obj.getD()).toEqual(12);
+      },
+      result: { x: 10, y: 2, getD: jasmine.any(Function) },
+      change: {
+        $set: { x: 10 },
+      },
+    }),
+
+    // getting a value using method functions in target (nested)
+    // ---------------------------------------------------------
+    () => ({
+      target: {
+        t: {
+          x: 1,
+          y: 2,
+          getD() {
+            return this.x + this.y;
+          },
+        },
+      },
+      action: (obj: any) => {
+        obj.t.x = 10;
+        expect(obj.t.getD()).toEqual(12);
+      },
+      result: { t: { x: 10, y: 2, getD: jasmine.any(Function) } },
+      change: {
+        $set: { 't.x': 10 },
+      },
+    }),
+
+    // getting a value using method functions in prototype
+    // ---------------------------------------------------
+    () => ({
+      target: new class {
+        x = 1;
+        y = 2;
+        public getD() {
+          return this.x + this.y;
+        }
+      }(),
+      action: (obj: any) => {
+        obj.x = 10;
+        expect(obj.getD()).toEqual(12);
+      },
+      result: { x: 10, y: 2 },
+      change: {
+        $set: { x: 10 },
+      },
+    }),
+
+    // getting a value using method functions in prototype (nested)
+    // ------------------------------------------------------------
+    () => ({
+      target: {
+        t: new class {
+          x = 1;
+          y = 2;
+          public getD() {
+            return this.x + this.y;
+          }
+        }(),
+      },
+      action: (obj: any) => {
+        obj.t.x = 10;
+        expect(obj.t.getD()).toEqual(12);
+      },
+      result: { t: { x: 10, y: 2 } },
+      change: {
+        $set: { 't.x': 10 },
+      },
+    }),
+
     // modify the object and check result multiple times
     // -------------------------------------------------
     () => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,9 +128,6 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
     if (typeof value === 'object') {
       return this.getKid(key, value);
     }
-    if (typeof value === 'function') {
-      return value.bind(this.proxy);
-    }
     return value;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,9 +271,6 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
    * Returns the getter function of a property if available. Checks prototypes as well.
    */
   private getGetterFunction(obj: any, key: KeyType): Function | null {
-    // if (obj.__lookupGetter__) {
-    //   return obj.__lookupGetter__[key];
-    // }
     for (let p = obj; p; p = Object.getPrototypeOf(p)) {
       const desc = Object.getOwnPropertyDescriptor(p, key);
       if (desc) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,15 @@ type KeyType = string | number | symbol;
 export class Sakota<T extends object> implements ProxyHandler<T> {
   /**
    * Wraps the given object with a Sakota proxy and returns it.
-   * This is the public function used to create
+   * This is the public function used to create the proxies.
    */
   public static create<T extends object>(obj: T): Proxied<T> {
     return Sakota._create(obj, null);
   }
 
   /**
-   *
+   * Wraps the given object with a Sakota proxy and returns it.
+   * Optionally sets the parent proxy agent when creating a new agent.
    */
   private static _create<T extends object>(obj: T, parent: Sakota<any> | null): Proxied<T> {
     const agent = new Sakota(obj, parent);


### PR DESCRIPTION
 - Use a common private static function `Sakota._create` from the public function `Sakota.create` and also from the `getKid` private method.
 - Fix a bug where when a getter property is accessed, it would call the getter function with original values instead of proxied values.