### PR TITLE
Ignore properties from Object.prototype

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 2019-05-23 - v2.4.1
+
+ - Fix an issue where proxied object does not have any methods from `Object.prototype`
+
 # 2019-05-21 - v2.4.0
 
  - Add support for javascript getters, previously it used to get called using original values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/sakota",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/sakota",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Proxies js objects and records all changes made on an object without modifying the object.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -18,6 +18,19 @@ export const values = () => [
   class {},
 ];
 
+export class Point {
+  constructor(
+    public x = 1,
+    public y = 2,
+  ) {}
+  get d() {
+    return this.x + this.y;
+  }
+  getD() {
+    return this.x + this.y;
+  }
+}
+
 /**
  * Proxies the object to throw when attempted to modify.
  */
@@ -240,18 +253,12 @@ describe('Sakota', () => {
     // getting a value using getter functions in prototype
     // ---------------------------------------------------
     () => ({
-      target: new class {
-        x = 1;
-        y = 2;
-        get d() {
-          return this.x + this.y;
-        }
-      }(),
+      target: new Point(),
       action: (obj: any) => {
         obj.x = 10;
         expect(obj.d).toEqual(12);
       },
-      result: { x: 10, y: 2 },
+      result: new Point(10, 2),
       change: {
         $set: { x: 10 },
       },
@@ -261,19 +268,13 @@ describe('Sakota', () => {
     // ------------------------------------------------------------
     () => ({
       target: {
-        t: new class {
-          x = 1;
-          y = 2;
-          get d() {
-            return this.x + this.y;
-          }
-        }(),
+        t: new Point(),
       },
       action: (obj: any) => {
         obj.t.x = 10;
         expect(obj.t.d).toEqual(12);
       },
-      result: { t: { x: 10, y: 2 } },
+      result: { t: new Point(10, 2) },
       change: {
         $set: { 't.x': 10 },
       },
@@ -324,18 +325,12 @@ describe('Sakota', () => {
     // getting a value using method functions in prototype
     // ---------------------------------------------------
     () => ({
-      target: new class {
-        x = 1;
-        y = 2;
-        public getD() {
-          return this.x + this.y;
-        }
-      }(),
+      target: new Point(),
       action: (obj: any) => {
         obj.x = 10;
         expect(obj.getD()).toEqual(12);
       },
-      result: { x: 10, y: 2 },
+      result: new Point(10, 2),
       change: {
         $set: { x: 10 },
       },
@@ -345,19 +340,13 @@ describe('Sakota', () => {
     // ------------------------------------------------------------
     () => ({
       target: {
-        t: new class {
-          x = 1;
-          y = 2;
-          public getD() {
-            return this.x + this.y;
-          }
-        }(),
+        t: new Point(),
       },
       action: (obj: any) => {
         obj.t.x = 10;
         expect(obj.t.getD()).toEqual(12);
       },
-      result: { t: { x: 10, y: 2 } },
+      result: { t: new Point(10, 2) },
       change: {
         $set: { 't.x': 10 },
       },

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -19,10 +19,7 @@ export const values = () => [
 ];
 
 export class Point {
-  constructor(
-    public x = 1,
-    public y = 2,
-  ) {}
+  constructor(public x = 1, public y = 2) {}
   get d() {
     return this.x + this.y;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
    */
   public deleteProperty(obj: any, key: KeyType): boolean {
     if (!(key in obj)) {
-      if (!this.diff || !this.diff.$set || !(this.diff.$set.hasOwnProperty(key))) {
+      if (!this.diff || !this.diff.$set || !this.diff.$set.hasOwnProperty(key)) {
         return true;
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,10 +93,10 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
    */
   public has(obj: any, key: string | number | symbol): any {
     if (this.diff) {
-      if (key in this.diff.$unset) {
+      if (this.diff.$unset.hasOwnProperty(key)) {
         return false;
       }
-      if (key in this.diff.$set) {
+      if (this.diff.$set.hasOwnProperty(key)) {
         return true;
       }
     }
@@ -111,10 +111,10 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
       return this;
     }
     if (this.diff) {
-      if (key in this.diff.$unset) {
+      if (this.diff.$unset.hasOwnProperty(key)) {
         return undefined;
       }
-      if (key in this.diff.$set) {
+      if (this.diff.$set.hasOwnProperty(key)) {
         return this.diff.$set[key as any];
       }
     }
@@ -161,10 +161,10 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
       return { configurable: true, enumerable: false, value: this };
     }
     if (this.diff) {
-      if (key in this.diff.$unset) {
+      if (this.diff.$unset.hasOwnProperty(key)) {
         return undefined;
       }
-      if (key in this.diff.$set) {
+      if (this.diff.$set.hasOwnProperty(key)) {
         return { configurable: true, enumerable: true, value: this.diff.$set[key] };
       }
     }
@@ -190,7 +190,7 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
    */
   public deleteProperty(obj: any, key: KeyType): boolean {
     if (!(key in obj)) {
-      if (!this.diff || !this.diff.$set || !(key in this.diff.$set)) {
+      if (!this.diff || !this.diff.$set || !(this.diff.$set.hasOwnProperty(key))) {
         return true;
       }
     }


### PR DESCRIPTION
The  and  objects on diff also has some properties which it gets from Object class, they should be ignored. Fixes issue where methods like hasOwnProperty on proxied objects become undefined.