### PR TITLE
Fix the Reflect.ownKeys return type miss match issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ export class Sakota<T extends object> implements ProxyHandler<T> {
   /**
    * Proxy handler trap for `Reflect.ownKeys()`.
    */
-  public ownKeys(obj: any): (string  | symbol)[] {
+  public ownKeys(obj: any): (string | symbol)[] {
     // FIXME: need to figure out why this return (string | number | symbol)[]
     // which is not the same as the return type of ES2015 Reflect.ownKeys.
     const keys = Reflect.ownKeys(obj) as (string | symbol)[];


### PR DESCRIPTION
Fix the Reflect.ownKeys return type miss-match issue


```
src/index.ts:203:5 - error TS2322: Type '(string | number | symbol)[]' is not assignable to type '(string | symbol)[]'.
  Type 'string | number | symbol' is not assignable to type 'string | symbol'.
    Type 'number' is not assignable to type 'string | symbol'.

203     return keys;
```

getting this error but ES2015 Reflect.ownKeys() return type is '(string | symbol)[]' but type script throw error saying that returning Type '(string | number | symbol)[]' . Fix that Cast it proper type
